### PR TITLE
[BUGFIX] Return the initial icon instead of nothing

### DIFF
--- a/Classes/Service/IconService.php
+++ b/Classes/Service/IconService.php
@@ -72,5 +72,6 @@ class IconService implements SingletonInterface
             $status['contexts'] = true;
             return 'extensions-contexts-status-overlay-contexts';
         }
+        return $iconName;
     }
 }


### PR DESCRIPTION
The missing `return` caused all icons in the pagetree to look the same regardless of states like "hide in menu" or "hidden".